### PR TITLE
Bugfix/messageformat

### DIFF
--- a/docs/integration/build-message.adoc
+++ b/docs/integration/build-message.adoc
@@ -300,7 +300,7 @@ The JSON setup looks like this:
 
 "capabilityAlternateId": "\{\{capabilityAlternateId}}",
 
-"measures": [{"\{\{encoded_request}}", "\{\{$timestamp}}"}]
+"measures": [["\{\{encoded_request}}", "\{\{$timestamp}}"]]
 
 }
 ----

--- a/docs/integration/build-message.adoc
+++ b/docs/integration/build-message.adoc
@@ -300,7 +300,7 @@ The JSON setup looks like this:
 
 "capabilityAlternateId": "\{\{capabilityAlternateId}}",
 
-"measures": [[{]"\{\{encoded_request}}", "\{\{$timestamp}}"}]
+"measures": [["\{\{encoded_request}}", "\{\{$timestamp}}"]]
 
 }
 ----

--- a/docs/integration/build-message.adoc
+++ b/docs/integration/build-message.adoc
@@ -300,7 +300,7 @@ The JSON setup looks like this:
 
 "capabilityAlternateId": "\{\{capabilityAlternateId}}",
 
-"measures": [["\{\{encoded_request}}", "\{\{$timestamp}}"]]
+"measures": [[{]"\{\{encoded_request}}", "\{\{$timestamp}}"}]
 
 }
 ----


### PR DESCRIPTION
measures [ [message,timestamp],[message,timestamp]] instead of [{message,timestamp},{message,timestamp}]