### PR TITLE
Call for endpoints, that can send or receive

### DIFF
--- a/docs/commands/ecosystem.adoc
+++ b/docs/commands/ecosystem.adoc
@@ -42,7 +42,7 @@ The direction describes, if messages shall be sendable or receivable:
 |Nr |Direction
 |0 |Send
 |1 |Receive
-|2 |Send and Receive
+|2 |Send or Receive
 |===================
 
 === Result


### PR DESCRIPTION
Currently it is a send OR receive in dke:list_endpoints but a send AND receive in dke:list_endpoints_unfiltered. The send OR receive makes much more sense, because otherwise there were no possibility to obtain a list of the endpoints with all their capabilities.