### PR TITLE
Update revoke.adoc

### DIFF
--- a/modules/ROOT/pages/integration/revoke.adoc
+++ b/modules/ROOT/pages/integration/revoke.adoc
@@ -47,7 +47,7 @@ The body includes a JSON object:
 |===============================================================================
 |# |Name |Type |Description
 |1 |accountId |String |The ID of the users account
-|2 |endpointIds |Array of String |An Array of endpointIds that shall be deleted.
+|2 |endpointIds |Array of String |An Array of endpointIds that shall be deleted. This is returned as the sensorAlternateId in the  xref:/integration/onboarding.html#success-2 [Onboard Response]
 |3 |UTCTimestamp |String |A timestamp like this: _2018-06-20T07:29:23.457Z_
 |4 |timeZone |String |A time zone like this: _"+03:00"_
 |===============================================================================


### PR DESCRIPTION
Proposing that the documentation makes it clear what "endpoint ids" is expecting. There are many "endpoint ids" through out agrirouter and its hard to know which one is expected.